### PR TITLE
Ensure Python Version Set Correctly in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      PIPENV_DEFAULT_PYTHON_VERSION: ${{matrix.python-version}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
         python-version: ["3.9"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         os: ["MacOS", "Ubuntu", "Windows"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   test:
     runs-on: ${{matrix.os}}-latest
+    env:
+      PIPENV_DEFAULT_PYTHON_VERSION: ${{matrix.python-version}}
     strategy:
       fail-fast: false
       matrix:

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-ipython = "*"
+ipython = {version = "*", python_version = ">= '3.8'"} # see: https://ipython.readthedocs.io/en/stable/whatsnew/version8.html#removing-support-for-older-python-versions
 pylint = "*"
 isort = "*"
 parameterized = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -308,6 +308,7 @@
                 "sha256:8138762243c9b3a3ffcf70b37151a2a35c23d3a29f9743878c33624f4207be3d"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==8.1.1"
         },
         "isort": {


### PR DESCRIPTION
Noticed that the Python version was not set correctly when jobs started failing [like this job](https://github.com/khwiri/jwt-debugger/actions/runs/3411674906/jobs/5676469538#step:4:161). That's because the virtual environment created by Pipenv was being initialized with Python 3.11 even when jobs were configured with other versions of Python. Specifically, Python 3.11 was causing this failure because of changes to [inspect](https://docs.python.org/3.11/library/inspect.html) where `formatargspec` was removed.